### PR TITLE
add --struct_patterns flag to choose types to lint

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -1,8 +1,11 @@
 package analyzer
 
 import (
+	"flag"
+	"fmt"
 	"go/ast"
 	"go/types"
+	"path"
 	"strings"
 
 	"golang.org/x/tools/go/analysis/passes/inspect"
@@ -17,10 +20,31 @@ var Analyzer = &analysis.Analyzer{
 	Doc:      "Checks if all struct's fields are initialized",
 	Run:      run,
 	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Flags:    newFlagSet(),
+}
+
+// StructPatternList is a comma separated list of expressions to match struct packages and names
+// The struct packages have the form example.com/package.ExampleStruct
+// The matching patterns can use matching syntax from https://pkg.go.dev/path#Match
+// If this list is empty, all structs are tested.
+var StructPatternList string
+
+func newFlagSet() flag.FlagSet {
+	fs := flag.NewFlagSet("", flag.PanicOnError)
+	fs.StringVar(&StructPatternList, "struct_patterns", "", "This is a comma separated list of expressions to match struct packages and names")
+	return *fs
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
 	inspector := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	structPatterns := strings.Split(StructPatternList, ",")
+	// validate the pattern syntax
+	for _, pattern := range structPatterns {
+		_, err := path.Match(pattern, "")
+		if err != nil {
+			return nil, fmt.Errorf("invalid struct pattern %s: %w", pattern, err)
+		}
+	}
 
 	nodeFilter := []ast.Node{
 		(*ast.CompositeLit)(nil),
@@ -53,6 +77,20 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		if t == nil {
 			return
+		}
+
+		if len(structPatterns) > 0 {
+			shouldLint := false
+			for _, pattern := range structPatterns {
+				// We check the patterns for vailidy ahead of time, so we don't need to check the error here
+				if match, _ := path.Match(pattern, t.String()); match {
+					shouldLint = true
+					break
+				}
+			}
+			if !shouldLint {
+				return
+			}
 		}
 
 		str, ok := t.Underlying().(*types.Struct)

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -16,5 +16,6 @@ func TestAll(t *testing.T) {
 	}
 
 	testdata := filepath.Join(filepath.Dir(filepath.Dir(wd)), "testdata")
+	analyzer.StructPatternList = "*.Test,*.Test2,*.Embedded,*.External"
 	analysistest.Run(t, testdata, analyzer.Analyzer, "s")
 }

--- a/testdata/src/s/s.go
+++ b/testdata/src/s/s.go
@@ -52,6 +52,19 @@ func shouldFailWithMissingFields() Test {
 	}
 }
 
+// Unchecked is a struct not listed in StructPatternList
+type Unchecked struct {
+	A int
+	B int
+}
+
+func unchecked() {
+	// This struct is not listed in StructPatternList so the linter won't complain that it's not filled out
+	_ = Unchecked{
+		A: 1,
+	}
+}
+
 func shouldFailOnEmbedded() Test2 {
 	return Test2{
 		Embedded: Embedded{ // want "E, H are missing in Embedded"


### PR DESCRIPTION
Usage:
```
exhaustivestruct: Checks if all struct's fields are initialized

Usage: exhaustivestruct [-flag] [package]


Flags:
...
  -struct_patterns string
        This is a comma separated list of expressions to match struct packages and names
```
Example:
```sh
exhaustivestruct -struct_patterns '*.Test,*.Test2,*.Embedded,*.External' ./...
```

I added a test and changed the analyzer test to use a struct pattern list. I expect the flexibility of https://pkg.go.dev/path#Match to be sufficient for this use case.

It would be a good idea to document this feature in the readme if we choose to merge it. @mbilski let me know if you want to do that or you want me to do a first draft.