### PR TITLE
Accept struct initialization without field names

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -153,13 +153,18 @@ func run(pass *analysis.Pass) (interface{}, error) {
 				continue
 			}
 
-			for _, e := range compositeLit.Elts {
+			for eIndex, e := range compositeLit.Elts {
 				if k, ok := e.(*ast.KeyValueExpr); ok {
 					if i, ok := k.Key.(*ast.Ident); ok {
 						if i.Name == fieldName {
 							exists = true
 							break
 						}
+					}
+				} else {
+					if eIndex == i {
+						exists = true
+						break
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does:**

Accept for example:

```go
type MyType struct {
	Name string
	Value int
}

obj := MyType{"Foo", 12}
```

Signed-off-by: Ji-Ping Shen ji-ping.shen@relexsolutions.com