### PR TITLE
Check init of private fields in the same package

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -143,13 +143,19 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			}
 		}
 
+		samePackage := strings.HasPrefix(t.String(), pass.Pkg.Path() + ".")
+
 		missing := []string{}
 
 		for i := 0; i < str.NumFields(); i++ {
 			fieldName := str.Field(i).Name()
 			exists := false
 
-			if !str.Field(i).Exported() {
+			if !samePackage && !str.Field(i).Exported() {
+				continue
+			}
+
+			if strings.HasPrefix(fieldName, "_") {
 				continue
 			}
 


### PR DESCRIPTION
**What this PR does:**

To check initialization in common constructors, e.g.

```go
type MyType struct {
	_msgpack struct{} `msgpack:",as_array"`
	name string
	value int
}

func NewMyType() MyType {
	return MyType{
		name: "foo",
		value: 10,
	}
}
```

PS: Fields starting with underscores are ignored

Signed-off-by: Ji-Ping Shen ji-ping.shen@relexsolutions.com